### PR TITLE
New GPU assignment mechanism

### DIFF
--- a/aws/lambda/premonitor.py
+++ b/aws/lambda/premonitor.py
@@ -1,12 +1,20 @@
+import re
 
 
 def lambda_handler(event, context):
+
+    name = "{}-{}-{}-monitor".format(
+        # only lowercase alphanumeric characters plus - and .
+        re.sub('[^0-9a-z-.]+', "?", event["data"]["submission"]["team_name"].lower().replace("_", "-").replace(" ", "-")),
+        event["data"]["submission"]["track_codename"].lower().replace("_", "-"),
+        event["data"]["submission"]["submission_id"]
+    )
 
     return {
         "cluster": event["data"]["cluster"],
         "submission": {
             "submission_id": event["data"]["submission"]["submission_id"],
-            "name": "monitor-{}".format(event["data"]["submission"]["submission_id"]),
+            "name": name,
             "challenge_id": event["data"]["submission"]["challenge_id"],
             "team_id": event["data"]["submission"]["team_id"],
             "track_id": event["data"]["submission"]["track_id"],

--- a/aws/lambda/preparallel.py
+++ b/aws/lambda/preparallel.py
@@ -1,4 +1,5 @@
 import math
+import re
 
 
 def lambda_handler(event, context):
@@ -10,11 +11,19 @@ def lambda_handler(event, context):
 
     out_ = []
     for worker_id, subset in enumerate(routes_subset):
+        name = "{}-{}-{}-worker{}".format(
+            # only lowercase alphanumeric characters plus - and .
+            re.sub('[^0-9a-z-.]+', "?", event["data"]["submission"]["team_name"].lower().replace("_", "-").replace(" ", "-")),
+            event["data"]["submission"]["track_codename"].lower().replace("_", "-"),
+            event["data"]["submission"]["submission_id"],
+            worker_id + 1
+        )
+
         out_.append({
             "cluster": event["data"]["cluster"],
             "submission": {
                 "submission_id": event["data"]["submission"]["submission_id"],
-                "name": "submission-{}-{}".format(event["data"]["submission"]["submission_id"], worker_id + 1),
+                "name": name,
                 "resume": event["data"]["submission"]["resume"],
                 "submitted_image_uri": event["data"]["submission"]["submitted_image_uri"],
                 "track_codename": event["data"]["submission"]["track_codename"],

--- a/leaderboard_2.0/docker/carla/Dockerfile
+++ b/leaderboard_2.0/docker/carla/Dockerfile
@@ -1,7 +1,5 @@
 
-FROM nvidia/vulkan:1.2.170-470
-
-RUN apt-key adv --fetch-keys "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub"
+FROM ubuntu:20.04
 
 RUN packages='libsdl2-2.0 xserver-xorg libvulkan1 libomp5' && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y $packages --no-install-recommends
 

--- a/leaderboard_2.0/docker/leaderboard/gpu_utils/get_gpu_device.sh
+++ b/leaderboard_2.0/docker/leaderboard/gpu_utils/get_gpu_device.sh
@@ -1,9 +1,9 @@
 
 #!/bin/bash
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GPU_DEVICE_FILE=${1}
 
-uuid=$(cat ${SCRIPT_DIR}/gpu.txt)
+uuid=$(cat ${GPU_DEVICE_FILE})
 
 readarray -t ALL_GPUS < <(nvidia-smi --query-gpu=index,uuid --format=csv | grep GPU)
 for gpu in "${ALL_GPUS[@]}"; do  if [[ "$gpu" == *"$uuid"* ]]; then DEVICE=$(cut -d , -f 1 <<< $gpu) && break ; fi; done

--- a/leaderboard_2.0/jobs/submission.yaml
+++ b/leaderboard_2.0/jobs/submission.yaml
@@ -39,8 +39,6 @@ spec:
                 echo "Detected a resume initiated by the user."
                 aws s3 rm s3://${S3_BUCKET}/${SUBMISSION_ID}/containers-status --recursive --exclude "*" --include "simulation.cancel"
               fi
-
-              bash /tmp/gpu_utils/get_gpu_uuid.sh > /tmp/gpu_utils/gpu.txt
           env:
             - name: SUBMISSION_ID
               value.$: $.submission.submission_id
@@ -61,9 +59,6 @@ spec:
               name: gpu-utils
             - mountPath: /tmp/logs
               name: logs
-          resources:
-            limits:
-              nvidia.com/gpu: 1
 
       containers:
         
@@ -72,7 +67,6 @@ spec:
           command: ["/bin/bash", "-c"]
           args:
             - |
-              export NVIDIA_VISIBLE_DEVICES=$(/gpu/get_gpu_device.sh)
               bash /home/carla/run_carla.sh
           env:
             - name: WORKER_ID
@@ -99,7 +93,6 @@ spec:
           command: ["/bin/bash", "-c"]
           args:
             - |
-              export NVIDIA_VISIBLE_DEVICES=$(/gpu/get_gpu_device.sh)
               bash /workspace/leaderboard/run_leaderboard.sh
           env:
             - name: WORKER_ID
@@ -132,6 +125,11 @@ spec:
               subPath: containers-status
             - mountPath: /workspace/log/ros
               name: ros-logs
+          # Set the resource gpu limit at the agent container. In this way, agents will only see one available GPU
+          # and we avoid users sending models to a different GPU from the assgined one.
+          resources:
+            limits:
+              nvidia.com/gpu: 1
 
         - name: aws-uploader
           image.$: $.cluster.uploader_image


### PR DESCRIPTION
This PR introduces a new GPU assignment mechanism for muti-gpu instances.

Previously, the container asking for the GPU was the `init` container. This container was registering the `UUID` of the assigned GPU by kubernetes and saving it in a shared volume for the other containers. The problem was that the containers not asking for the GPU had all the GPUs visible.

Now, the container asking for the GPU is the `agent` container. In this way, agents will only see one available GPU and we avoid users sending models to a different GPU from the assigned one.

Also, `team_name` and `track_codename` values have been added in the `pod` name.